### PR TITLE
Add package data entries to MANIFEST.ini

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+# added by check-manifest
+recursive-include src *.c
+recursive-include src *.h
+recursive-include src *.pxd
+recursive-include src *.pyx
+recursive-include src Makefile
+recursive-include tests *.py
+recursive-include tests *.pyx


### PR DESCRIPTION
Wonderful package.  Debugging Cython is so much easier using cytool.  Thank you.

In order for the sample and test source files to be included in the installed package when build from source using python-build and other such tools, MANIFEST.ini requires entries such as these.

Without such "cytool initialize . --include-samples --include-boilerplate --boilerplate-name=cytoolz" only gets the .py files as they missing from the dist tar file.

Have a wonderful day!
